### PR TITLE
feat(covenants): Added support for CAT, CTV, and CSFS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,12 +680,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoinkernel"
+name = "bitcoinkernel-covenants"
 version = "0.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a682fd5bdd4ca6cbd6090e6c014d6a180509e4a4ae30e044e3625cef588005e"
+checksum = "f37f4279ddba65f3afe3692c5a046c760231136e1268c4fd04711700e41e5474"
 dependencies = [
- "libbitcoinkernel-sys",
+ "libbitcoinkernel-sys-covenants",
 ]
 
 [[package]]
@@ -816,7 +816,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bitcoin",
- "bitcoinkernel",
+ "bitcoinkernel-covenants",
  "confidential-script-lib",
  "confidential-script-wire",
  "hex",
@@ -1674,10 +1674,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "libbitcoinkernel-sys"
+name = "libbitcoinkernel-sys-covenants"
 version = "0.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bdc51625a5644edf6c31030cd1b35fe4612af65680bcf8ca2ff830c40bcf29d"
+checksum = "1fdad2bcc5280c2531bb69d27af8f5d8fe296c235af0f0b0b09c718b15701298"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ anyhow.workspace = true
 aws-config = { version = "1.1" }
 aws-sdk-kms = { version = "1.15" }
 axum = { version = "0.7", features = ["macros"] }
-bitcoinkernel = "0.0.23"
+bitcoinkernel-covenants = "0.0.23"
 bitcoin.workspace = true
 confidential-script-lib = "0.3.1"
 confidential-script-wire = { version = "0.1.0", path = "crates/confidential-script-wire" }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,6 +7,7 @@ use bitcoin::{
     secp256k1::{PublicKey, Secp256k1, SecretKey},
     taproot::{LeafVersion, TaprootBuilder},
 };
+use bitcoinkernel_covenants as bitcoinkernel;
 use confidential_script::{
     AppState, MAX_PAYLOAD_SIZE,
     api::{encryption_middleware::encryption_middleware, verify_and_sign_handler},


### PR DESCRIPTION
This PR adds (preliminary) support for `OP_CAT`, `OP_CTV`, and `OP_CSFS` via `rust-bitcoinkernel-covenants` by @stutxo, replacing the standard `rust-bitcoinkernel`.